### PR TITLE
Added beginFrame/endFrame methods

### DIFF
--- a/LibOVR/Include/OVR_Version.h
+++ b/LibOVR/Include/OVR_Version.h
@@ -33,3 +33,4 @@ limitations under the License.
 #define OVR_DK2_LATEST_FIRMWARE_MAJOR_VERSION 2
 #define OVR_DK2_LATEST_FIRMWARE_MINOR_VERSION 12
 #endif
+ 

--- a/include/CinderOculus.cpp
+++ b/include/CinderOculus.cpp
@@ -410,6 +410,20 @@ void OculusRift::detachFromWindow()
 	mWindow.reset();
 }
 
+void OculusRift::beginFrame() const
+{
+	if ( mFbo ) {
+		mFbo->bindFramebuffer();
+	}
+}
+
+void OculusRift::endFrame() const
+{
+	if ( mFbo ) {
+		mFbo->unbindFramebuffer();
+	}
+}
+
 void OculusRift::enableEye( int eyeIndex, bool applyMatrices )
 {
 	mProjectionCached = mViewMatrixCached = mInverseViewMatrixCached = false;
@@ -621,12 +635,9 @@ void OculusRift::startDrawFn( Renderer *renderer )
 		hmdToEyeViewOffset[1].x = 0; //  received from the loaded profile. 
 	}
 	ovrHmd_GetEyePoses( mHmd, 0, hmdToEyeViewOffset, mEyeRenderPose, &mTrackingState );
-
-	mFbo->bindFramebuffer();
 }
 
 void OculusRift::finishDrawFn( Renderer *renderer )
 {
-	mFbo->unbindFramebuffer();
 	mImpl->endFrame( renderer );
 }

--- a/include/CinderOculus.cpp
+++ b/include/CinderOculus.cpp
@@ -410,14 +410,14 @@ void OculusRift::detachFromWindow()
 	mWindow.reset();
 }
 
-void OculusRift::beginFrame() const
+void OculusRift::bind() const
 {
 	if ( mFbo ) {
 		mFbo->bindFramebuffer();
 	}
 }
 
-void OculusRift::endFrame() const
+void OculusRift::unbind() const
 {
 	if ( mFbo ) {
 		mFbo->unbindFramebuffer();
@@ -641,3 +641,4 @@ void OculusRift::finishDrawFn( Renderer *renderer )
 {
 	mImpl->endFrame( renderer );
 }
+ 

--- a/include/CinderOculus.h
+++ b/include/CinderOculus.h
@@ -40,9 +40,7 @@
 
 #include "cinder/app/RendererGl.h"
 #include "cinder/app/Window.h"
-#include "cinder/gl/Batch.h"
-#include "cinder/gl/Fbo.h"
-#include "cinder/gl/GlslProg.h"
+#include "cinder/gl/gl.h"
 #include "cinder/gl/Texture.h"
 #include "cinder/Camera.h"
 
@@ -174,6 +172,9 @@ public:
 	
 	bool	attachToWindow( const ci::app::WindowRef &window );
 	void	detachFromWindow();
+
+	void beginFrame() const;
+	void endFrame() const;
 
 	//! Set the base viewpoint position and orientation through the host camera.
 	void	setHostCamera( const ci::CameraPersp& camera ) { mHostCamera = camera; }

--- a/include/CinderOculus.h
+++ b/include/CinderOculus.h
@@ -41,7 +41,6 @@
 #include "cinder/app/RendererGl.h"
 #include "cinder/app/Window.h"
 #include "cinder/gl/gl.h"
-#include "cinder/gl/Texture.h"
 #include "cinder/Camera.h"
 
 #include "OVR_Kernel.h"
@@ -146,12 +145,13 @@ inline ovrQuatf toOvr( const glm::quat& q )
 
 static const float kLeapToRiftScale = 0.01f;
 static const glm::vec3 kLeapToRiftEuler = glm::vec3( -0.5f * (float)M_PI, 0, (float)M_PI );
- 
+
 ////////////////////////////////////////////////////////////////////////
-	
+
 class OculusRift;
 
-class RiftManager : public ci::Noncopyable {
+class RiftManager : public ci::Noncopyable 
+{
 public:
 	~RiftManager();	
 	static void initialize();
@@ -165,7 +165,8 @@ private:
 
 typedef std::shared_ptr<OculusRift> OculusRiftRef;
 
-class OculusRift {
+class OculusRift 
+{
 public:
 	explicit OculusRift();
 	~OculusRift();
@@ -173,8 +174,8 @@ public:
 	bool	attachToWindow( const ci::app::WindowRef &window );
 	void	detachFromWindow();
 
-	void beginFrame() const;
-	void endFrame() const;
+	void	bind() const;
+	void	unbind() const;
 
 	//! Set the base viewpoint position and orientation through the host camera.
 	void	setHostCamera( const ci::CameraPersp& camera ) { mHostCamera = camera; }
@@ -251,7 +252,8 @@ public:
 	bool isDesktopExtended() const;
 private:
 
-	class HmdEyeCamera : public ci::CameraPersp {
+	class HmdEyeCamera : public ci::CameraPersp 
+	{
 	protected:
 		void calcProjection() const override
 		{
@@ -313,6 +315,5 @@ private:
 	friend class OculusRift::ExtendedModeImpl;
 };
 
-
-
-} // namespace rift
+} // namespace hmd
+ 

--- a/samples/BasicSample/src/BasicSampleApp.cpp
+++ b/samples/BasicSample/src/BasicSampleApp.cpp
@@ -99,7 +99,7 @@ void BasicSampleApp::draw()
 		gl::drawSphere( vec3( mLightWorldPosition ), 0.05f, 36 );
 	};
 	
-	mRift.beginFrame();
+	mRift.bind();
 	gl::clear( Color::gray( 0 ) );
 
 	if( mRift.hasWindow( getWindow() ) ) {
@@ -129,7 +129,7 @@ void BasicSampleApp::draw()
 
 		sceneDraw();
 	}
-	mRift.endFrame();
+	mRift.unbind();
 }
 
 void BasicSampleApp::resize()

--- a/samples/BasicSample/src/BasicSampleApp.cpp
+++ b/samples/BasicSample/src/BasicSampleApp.cpp
@@ -85,8 +85,6 @@ void BasicSampleApp::update()
 
 void BasicSampleApp::draw()
 {
-	gl::clear( Color::gray( 0 ) );
-	
 	auto sceneDraw = [&]() {
 		{
 			gl::ScopedModelMatrix push;
@@ -101,6 +99,9 @@ void BasicSampleApp::draw()
 		gl::drawSphere( vec3( mLightWorldPosition ), 0.05f, 36 );
 	};
 	
+	mRift.beginFrame();
+	gl::clear( Color::gray( 0 ) );
+
 	if( mRift.hasWindow( getWindow() ) ) {
 		for( auto eye : mRift.getEyes() ) {
 			mRift.enableEye( eye );
@@ -128,6 +129,7 @@ void BasicSampleApp::draw()
 
 		sceneDraw();
 	}
+	mRift.endFrame();
 }
 
 void BasicSampleApp::resize()

--- a/samples/InstancedStereo/src/InstancedStereoApp.cpp
+++ b/samples/InstancedStereo/src/InstancedStereoApp.cpp
@@ -69,7 +69,7 @@ void InstancedStereoApp::update()
 
 void InstancedStereoApp::draw()
 {
-	mRift.beginFrame();
+	mRift.bind();
 	gl::clear();
 	std::array<mat4, 6> worldToEyeClipMatrices;
 
@@ -102,7 +102,7 @@ void InstancedStereoApp::draw()
 		mShader->uniform( "uWorldToEyeClipMatrices", worldToEyeClipMatrices.data(), 6 );
 		mTeapot->drawInstanced( 2 );
 	}
-	mRift.endFrame();
+	mRift.unbind();
 }
 
 void InstancedStereoApp::keyDown( KeyEvent event )

--- a/samples/InstancedStereo/src/InstancedStereoApp.cpp
+++ b/samples/InstancedStereo/src/InstancedStereoApp.cpp
@@ -1,8 +1,6 @@
 #include "cinder/app/App.h"
 #include "cinder/app/RendererGl.h"
 #include "cinder/gl/gl.h"
-#include "cinder/gl/Batch.h"
-#include "cinder/gl/Context.h"
 #include "cinder/Log.h"
 #include "cinder/MayaCamUI.h"
 #include "cinder/Utilities.h"
@@ -71,6 +69,7 @@ void InstancedStereoApp::update()
 
 void InstancedStereoApp::draw()
 {
+	mRift.beginFrame();
 	gl::clear();
 	std::array<mat4, 6> worldToEyeClipMatrices;
 
@@ -103,6 +102,7 @@ void InstancedStereoApp::draw()
 		mShader->uniform( "uWorldToEyeClipMatrices", worldToEyeClipMatrices.data(), 6 );
 		mTeapot->drawInstanced( 2 );
 	}
+	mRift.endFrame();
 }
 
 void InstancedStereoApp::keyDown( KeyEvent event )

--- a/samples/SphericalStereo/src/SphericalStereoApp.cpp
+++ b/samples/SphericalStereo/src/SphericalStereoApp.cpp
@@ -1,8 +1,6 @@
 #include "cinder/app/App.h"
 #include "cinder/app/RendererGl.h"
 #include "cinder/gl/gl.h"
-#include "cinder/gl/Batch.h"
-#include "cinder/gl/Context.h"
 #include "cinder/Log.h"
 #include "cinder/gl/VboMesh.h"
 #include "cinder/MayaCamUI.h"
@@ -86,6 +84,7 @@ void SphericalStereoApp::update()
 
 void SphericalStereoApp::draw()
 {
+	mRift.beginFrame();
 	gl::clear();
 
 	if( mRift.hasWindow( getWindow() ) ) {
@@ -113,6 +112,7 @@ void SphericalStereoApp::draw()
 			}
 		}
 	}
+	mRift.endFrame();
 }
 
 void SphericalStereoApp::fileDrop( FileDropEvent event )

--- a/samples/SphericalStereo/src/SphericalStereoApp.cpp
+++ b/samples/SphericalStereo/src/SphericalStereoApp.cpp
@@ -84,7 +84,7 @@ void SphericalStereoApp::update()
 
 void SphericalStereoApp::draw()
 {
-	mRift.beginFrame();
+	mRift.bind();
 	gl::clear();
 
 	if( mRift.hasWindow( getWindow() ) ) {
@@ -112,7 +112,7 @@ void SphericalStereoApp::draw()
 			}
 		}
 	}
-	mRift.endFrame();
+	mRift.unbind();
 }
 
 void SphericalStereoApp::fileDrop( FileDropEvent event )


### PR DESCRIPTION
Added beginFrame/endFrame methods to control FBO bind. This lets the user work with FBOs in draw() before rendering to the Rift.
